### PR TITLE
enhancement/upgrade greenwood v0.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.29.0",
-        "@greenwood/plugin-adapter-netlify": "~0.29.0",
+        "@greenwood/cli": "~0.29.2",
+        "@greenwood/plugin-adapter-netlify": "~0.29.2",
         "rimraf": "^5.0.0"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.2.tgz",
+      "integrity": "sha512-rjJocodVI23TTS5K8ASYFSdrbldyDDQu0Xi9vkLLfzhZezmhOs55dxCpTEGAw+7O5lcq1giew74PZBpqu8Slug==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -42,7 +42,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.10.0"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@greenwood/plugin-adapter-netlify": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-netlify/-/plugin-adapter-netlify-0.29.0.tgz",
-      "integrity": "sha512-jAb16uG2TZMNvv90vFd9g2cq3UvO4Lu9qehv2DHcUBCNF+rvIaPkWLrVUXFFsPchRj+atNfr/d7mCOPa1YZaeg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-netlify/-/plugin-adapter-netlify-0.29.2.tgz",
+      "integrity": "sha512-kVlq8/Yy4Yel5Z+VAD7MGjsXLzg/fq4rsoWX0/z8No08Lf0CMr29beydLoeqC3J3U4CaI4JbzjHZaC78Tb7XeA==",
       "dev": true,
       "dependencies": {
         "netlify-cli": "^15.10.0",
@@ -19946,9 +19946,9 @@
   },
   "dependencies": {
     "@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.2.tgz",
+      "integrity": "sha512-rjJocodVI23TTS5K8ASYFSdrbldyDDQu0Xi9vkLLfzhZezmhOs55dxCpTEGAw+7O5lcq1giew74PZBpqu8Slug==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -19977,9 +19977,9 @@
       }
     },
     "@greenwood/plugin-adapter-netlify": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-netlify/-/plugin-adapter-netlify-0.29.0.tgz",
-      "integrity": "sha512-jAb16uG2TZMNvv90vFd9g2cq3UvO4Lu9qehv2DHcUBCNF+rvIaPkWLrVUXFFsPchRj+atNfr/d7mCOPa1YZaeg==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-netlify/-/plugin-adapter-netlify-0.29.2.tgz",
+      "integrity": "sha512-kVlq8/Yy4Yel5Z+VAD7MGjsXLzg/fq4rsoWX0/z8No08Lf0CMr29beydLoeqC3J3U4CaI4JbzjHZaC78Tb7XeA==",
       "dev": true,
       "requires": {
         "netlify-cli": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,9 @@
     "serve:netlify": "greenwood build && netlify dev",
     "start": "npm run serve"
   },
-  "overrides": {
-    "wc-compiler": "~0.10.0"
-  },
   "devDependencies": {
-    "@greenwood/cli": "~0.29.0",
-    "@greenwood/plugin-adapter-netlify": "~0.29.0",
+    "@greenwood/cli": "~0.29.2",
+    "@greenwood/plugin-adapter-netlify": "~0.29.2",
     "rimraf": "^5.0.0"
   }
 }


### PR DESCRIPTION
This should pull in latest **wc-compiler** from Greenwood with [`shadowrootmode` support](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.29.2)
![Screenshot 2024-01-27 at 5 11 18 PM](https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/assets/895923/a3103b9f-feec-436f-9fb1-18322bbe288a)
```sh
npm ls wc-compiler                             
greenwood-demo-adapter-netlify@1.0.0 /Users/owenbuckley/Workspace/project-evergreen/greenwood-demo-adapter-netlify
└─┬ @greenwood/cli@0.29.2
  └── wc-compiler@0.10.0
```